### PR TITLE
initial styling

### DIFF
--- a/liqd_product/assets/scss/_variables.scss
+++ b/liqd_product/assets/scss/_variables.scss
@@ -1,0 +1,48 @@
+// subset of bootstrap variables
+
+$body-bg: #fff;
+$bg-secondary: #f5f5f5;
+$bg-tertiary: #e6e6e6;
+$text-color: #191919;
+$text-color-inverted: $body-bg;
+$shadow: rgba(#000, 0.25);
+
+$brand-primary: contrast-stretch($body-bg, #328ee1);
+$brand-primary-tint: contrast-stretch($text-color, #328ee1);
+$brand-secondary: #253276;
+$brand-success: #0a820a;
+$brand-info: #fdd216;
+$brand-warning: #f0ad4e;
+$brand-danger: #dc3918;
+
+$link-color: $brand-primary;
+$link-hover-color: darken($link-color, 15%);
+
+$border-color: #ccc;
+$input-border-color: $border-color;
+
+$feedback-color-accepted: #0a820a;
+$feedback-color-rejected: #dc3818;
+$feedback-color-consideration: #ffae00;
+
+$spacer: 1em;
+$padding: 1rem;
+
+$font-family-sans-serif: "Arial", "Helvetica", sans-serif;
+
+$font-size-xxl: 1.95rem;
+$font-size-xl: 1.56rem;
+$font-size-lg: 1.25rem;
+$font-size-sm: 0.8rem;
+$font-size-xs: 0.64rem;
+
+$breakpoint: 50em;
+$breakpoint-md: 64em;
+
+$hero-height: 41em;
+$hero-height-secondary: 30em;
+$hero-height-mobile: 10.4em;
+
+@include grid-set('gutter', $padding);
+$planifolia-contrast-dark-default: $text-color;
+$planifolia-contrast-light-default: $text-color-inverted;

--- a/liqd_product/assets/scss/style.scss
+++ b/liqd_product/assets/scss/style.scss
@@ -1,1 +1,60 @@
-// Intentionally left blank
+@import '~sass-planifolia/sass/grid';
+@import '~sass-planifolia/sass/contrast';
+
+@import 'variables';
+@import '~a4-meinberlin/meinberlin/assets/scss/mixins';
+
+@import '~bootstrap/scss/variables';
+@import '~bootstrap/scss/mixins';
+@import '~bootstrap/scss/modal';
+@import '~bootstrap/scss/close';
+@import '~bootstrap/scss/transitions';
+@import '~bootstrap/scss/popover';
+@import '~bootstrap/scss/utilities/screenreaders';
+
+@import '~a4-meinberlin/meinberlin/assets/scss/base';
+@import '~a4-meinberlin/meinberlin/assets/scss/layout';
+@import '~a4-meinberlin/meinberlin/assets/scss/form';
+
+@import '~a4-meinberlin/meinberlin/assets/scss/components/action';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/alert';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/blocks';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/breadcrumbs';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/button';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/commenting';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/comments';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/dashboard_nav';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/datepicker';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/document';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/dropdown';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/embed_layout';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/embed_status';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/filter_bar';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/fixed_side';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/footer';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/formset';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/header';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/hero_unit';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/item_detail';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/label';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/list_item';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/lr_bar';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/map';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/menu_layout';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/moderator_statement';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/module';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/multiform';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/pagination';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/timeline';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/poll';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/project_header';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/radio';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/rating';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/simple_page';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/table';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/tabs';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/tile';
+@import '~a4-meinberlin/meinberlin/assets/scss/components/upload';
+
+@import '~a4-meinberlin/meinberlin/assets/scss/utility';
+@import '~a4-meinberlin/meinberlin/assets/scss/shame';

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "repository": "https://github.com/liqd/liqd-product.git",
   "dependencies": {
     "adhocracy4": "github:liqd/adhocracy4#master",
+    "a4-meinberlin": "github:liqd/a4-meinberlin#master",
     "autoprefixer": "^7.1.1",
     "babel-core": "^6.25.0",
     "babel-loader": "^6.4.1",


### PR DESCRIPTION
This completely reuses meinberlin styling, but with different variables.

My plan is to replace the meinberlin imports by local files one by one as required.

You need to have a4-meinberlin installed with npm. It is not packages yet, so you have to use the `npm link` method.