### PR TITLE
Add project tiles to partner landing page

### DIFF
--- a/liqd_product/apps/partners/templates/partner_landing_page.html
+++ b/liqd_product/apps/partners/templates/partner_landing_page.html
@@ -62,7 +62,6 @@
                                 enjoy doing motorsports like car racing.
                             </p>
                             <p class="project-tile__date">9. August 2017 - 16. August 2017</p>
-
                         </div>
                     </div>
                 </li>
@@ -73,7 +72,6 @@
             <div class="aside__block">
                 <h2 class="aside__block__title heading2">{% trans 'About this page' %}</h2>
                 <p>{{partner.description}}</p>
-
             </div>
 
             <div class="aside__block">

--- a/liqd_product/apps/partners/templates/partner_landing_page.html
+++ b/liqd_product/apps/partners/templates/partner_landing_page.html
@@ -24,6 +24,9 @@
                         </div>
                         <div class="project-tile__body">
                             <h3 class="project-tile__title h4">Fußballturnier Falkensee</h3>
+                            <span class="label">3 days left</span>
+                            <span class="label label--primary">active</span>
+                            <span class="label label--danger">finished</span>
                             <p class="project-tile__description">
                                 The world should stop complaining
                                 about the life and should

--- a/liqd_product/apps/partners/templates/partner_landing_page.html
+++ b/liqd_product/apps/partners/templates/partner_landing_page.html
@@ -12,13 +12,57 @@
 
     <div class="l-wrapper">
         <main class="l-col-8-0">
-            {{partner.slogan}}
+            <ul class="u-list-reset">
+                <li>
+                    <div class="project-tile">
+                        <div class="project-tile__picture">
+                            <a href="https://placeholder.com">
+                                <img class="project-tile__picture"
+                                     src="http://via.placeholder.com/370x217" />
+                            </a>
+                            <!--#370 zu 400-->
+                        </div>
+                        <div class="project-tile__body">
+                            <h3 class="project-tile__title h4">Fußballturnier Falkensee</h3>
+                            <p class="project-tile__description">
+                                The world should stop complaining
+                                about the life and should
+                                have fun at doing sports
+                                like real soccer.
+                            </p>
+                            <p class="project-tile__date">9. August 2017 - 16. August 2017</p>
+                        </div>
+                    </div>
+                </li>
+                <li>
+                    <div class="project-tile">
+                        <div class="project-tile__picture">
+                            <a href="https://placeholder.com">
+                                <img class="project-tile__picture"
+                                     src="http://via.placeholder.com/370x217" />
+                            </a>
+                            <!--#370 zu 400-->
+                        </div>
+                        <div class="project-tile__body">
+                            <h3 class="project-tile__title h4">Autorennen Falkensee</h3>
+                            <p class="project-tile__description">
+                                The world should stop complaining
+                                about the life and should
+                                enjoy doing motorsports like car racing.
+                            </p>
+                            <p class="project-tile__date">9. August 2017 - 16. August 2017</p>
+
+                        </div>
+                    </div>
+                </li>
+            </ul>
         </main>
 
         <aside class="l-col-4-8 aside">
             <div class="aside__block">
                 <h2 class="aside__block__title">Über diese Seite</h2>
                 <p>{{partner.description}}</p>
+
             </div>
 
             <div class="aside__block">

--- a/liqd_product/apps/partners/templates/partner_landing_page.html
+++ b/liqd_product/apps/partners/templates/partner_landing_page.html
@@ -16,9 +16,13 @@
                 <li>
                     <div class="project-tile">
                         <div class="project-tile__picture">
-                            <a href="https://placeholder.com">
-                                <img class="project-tile__picture"
-                                     src="http://via.placeholder.com/370x217" />
+                            <a tabindex="-1"
+                               class="tile__image project-tile__picture"
+                               aria-labelledby="project-title-90"
+                               style="background-image: url(
+                               http://via.placeholder.com/1000x2500)"
+                               href="https://placeholder.com"
+                               target="_self">
                             </a>
                             <!--#370 zu 400-->
                         </div>
@@ -40,9 +44,13 @@
                 <li>
                     <div class="project-tile">
                         <div class="project-tile__picture">
-                            <a href="https://placeholder.com">
-                                <img class="project-tile__picture"
-                                     src="http://via.placeholder.com/370x217" />
+                            <a tabindex="-1"
+                               class="tile__image project-tile__picture"
+                               aria-labelledby="project-title-90"
+                               style="background-image: url(
+                               http://via.placeholder.com/800x800)"
+                               href="https://placeholder.com"
+                               target="_self">
                             </a>
                             <!--#370 zu 400-->
                         </div>

--- a/liqd_product/apps/partners/templates/partner_landing_page.html
+++ b/liqd_product/apps/partners/templates/partner_landing_page.html
@@ -28,9 +28,11 @@
                         </div>
                         <div class="project-tile__body">
                             <h3 class="project-tile__title h4">Fußballturnier Falkensee</h3>
-                            <span class="label">3 days left</span>
-                            <span class="label label--primary">active</span>
-                            <span class="label label--danger">finished</span>
+                            <div class="project-tile__labels">
+                                <span class="label">3 days left</span>
+                                <span class="label label--primary">active</span>
+                                <span class="label label--danger">finished</span>
+                            </div>
                             <p class="project-tile__description">
                                 The world should stop complaining
                                 about the life and should

--- a/liqd_product/apps/partners/views.py
+++ b/liqd_product/apps/partners/views.py
@@ -1,6 +1,7 @@
 from django.views.generic import DetailView
 
 from adhocracy4.actions.models import Action
+from adhocracy4.projects.models import Project
 from liqd_product.apps.partners.models import Partner
 
 
@@ -13,4 +14,5 @@ class PartnerView(DetailView):
         context = super(PartnerView, self).get_context_data(**kwargs)
         # FIXME: limit to current partner
         context['action_list'] = Action.objects.all()[:10]
+        context['project_list'] = Project.objects.all()[:3]
         return context

--- a/liqd_product/assets/scss/_layout.scss
+++ b/liqd_product/assets/scss/_layout.scss
@@ -1,11 +1,9 @@
-.l-col-8-0 {
-    @media (min-width: $breakpoint) {
+@media (min-width: $breakpoint) {
+    .l-col-8-0 {
         @include grid-span(8, 0);
     }
-}
 
-.l-col-4-8 {
-    @media (min-width: $breakpoint) {
+    .l-col-4-8 {
         @include grid-span(4, 8);
     }
 }

--- a/liqd_product/assets/scss/_layout.scss
+++ b/liqd_product/assets/scss/_layout.scss
@@ -1,9 +1,13 @@
 .l-col-8-0 {
-    @include grid-span(8, 0);
+    @media (min-width: $breakpoint) {
+        @include grid-span(8, 0);
+    }
 }
 
 .l-col-4-8 {
-    @include grid-span(4, 8);
+    @media (min-width: $breakpoint) {
+        @include grid-span(4, 8);
+    }
 }
 
 .l-outer-wrapper {

--- a/liqd_product/assets/scss/_variables.scss
+++ b/liqd_product/assets/scss/_variables.scss
@@ -17,6 +17,9 @@ $brand-info: #fdd216;
 $brand-warning: #f0ad4e;
 $brand-danger: #dc3918;
 
+$platform-primary: #46caad;
+$platform-danger: #d0011b;
+
 $link-color: $brand-primary;
 $link-hover-color: darken($link-color, 15%);
 

--- a/liqd_product/assets/scss/components/_hero-unit.scss
+++ b/liqd_product/assets/scss/components/_hero-unit.scss
@@ -39,6 +39,7 @@
     line-height: 1.2;
     text-align: center;
     font-size: $font-size-xl;
+    font-weight: bold;
 
     @media screen and (min-width: $breakpoint) {
         font-size: $font-size-xxl;

--- a/liqd_product/assets/scss/components/_label.scss
+++ b/liqd_product/assets/scss/components/_label.scss
@@ -1,0 +1,40 @@
+.label {
+    display: inline-block;
+    background-color: $text-color;
+    color: contrast-color($text-color);
+    font-size: $font-size-xs;
+    font-weight: normal;
+    border-radius: 0.4em;
+    padding: 0.2em 0.7em;
+}
+
+.label--big {
+    padding: 0.4em 0.6em;
+    font-size: $font-size-sm;
+    border-radius: 0.3em;
+}
+
+.label--primary {
+    background-color: $platform-primary;
+    color: contrast-color($platform-primary, $text-color-inverted);
+}
+
+.label--danger {
+    background-color: $platform-danger;
+    color: contrast-color($platform-danger);
+}
+
+.label--CONSIDERATION {
+    background-color: $feedback-color-consideration;
+    color: contrast-color($feedback-color-consideration);
+}
+
+.label--REJECTED {
+    background-color: $feedback-color-rejected;
+    color: contrast-color($feedback-color-rejected);
+}
+
+.label--ACCEPTED {
+    background-color: $feedback-color-accepted;
+    color: contrast-color($feedback-color-accepted);
+}

--- a/liqd_product/assets/scss/components/_project-tile.scss
+++ b/liqd_product/assets/scss/components/_project-tile.scss
@@ -1,11 +1,16 @@
 .project-tile {
-    display: flex;
+    @media (min-width: $breakpoint) {
+        display: flex;
+    }
     box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);
     margin-bottom: 0.6em;
 }
 
 .project-tile__picture {
-    display: block;
+    @media (min-width: $breakpoint) {
+        display: block;
+        width: 100%;
+    }
 }
 
 .project-tile__title {

--- a/liqd_product/assets/scss/components/_project-tile.scss
+++ b/liqd_product/assets/scss/components/_project-tile.scss
@@ -1,0 +1,26 @@
+.project-tile {
+    display: flex;
+    box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);
+    margin-bottom: 0.6em;
+}
+
+.project-tile__picture {
+    display: block;
+}
+
+.project-tile__title {
+    margin: 0;
+}
+
+.project-tile__body {
+    padding: 1.25em;
+}
+
+.project-tile__date {
+    color: $text-secondary-color;
+    margin: 0;
+}
+
+.project-tile__description {
+    margin: 0;
+}

--- a/liqd_product/assets/scss/style.scss
+++ b/liqd_product/assets/scss/style.scss
@@ -58,14 +58,14 @@
 @import '~a4-meinberlin/meinberlin/assets/scss/components/upload';
 
 @import 'components/aside';
+@import 'components/footer';
 @import 'components/header';
 @import 'components/headings';
 @import "components/hero-unit";
-@import 'components/footer';
-@import 'components/navi';
-@import 'components/stats';
-@import 'components/project-tile';
 @import 'components/label';
+@import 'components/navi';
+@import 'components/project-tile';
+@import 'components/stats';
 
 @import '~a4-meinberlin/meinberlin/assets/scss/utility';
 @import '~a4-meinberlin/meinberlin/assets/scss/shame';

--- a/liqd_product/assets/scss/style.scss
+++ b/liqd_product/assets/scss/style.scss
@@ -64,6 +64,7 @@
 @import 'components/navi';
 @import 'components/stats';
 @import 'components/project-tile';
+@import 'components/label';
 
 @import '~a4-meinberlin/meinberlin/assets/scss/utility';
 @import '~a4-meinberlin/meinberlin/assets/scss/shame';

--- a/liqd_product/assets/scss/style.scss
+++ b/liqd_product/assets/scss/style.scss
@@ -37,7 +37,6 @@
 @import '~a4-meinberlin/meinberlin/assets/scss/components/fixed_side';
 @import '~a4-meinberlin/meinberlin/assets/scss/components/formset';
 @import '~a4-meinberlin/meinberlin/assets/scss/components/item_detail';
-@import '~a4-meinberlin/meinberlin/assets/scss/components/label';
 @import '~a4-meinberlin/meinberlin/assets/scss/components/list_item';
 @import '~a4-meinberlin/meinberlin/assets/scss/components/lr_bar';
 @import '~a4-meinberlin/meinberlin/assets/scss/components/map';

--- a/liqd_product/assets/scss/style.scss
+++ b/liqd_product/assets/scss/style.scss
@@ -63,6 +63,7 @@
 @import 'components/footer';
 @import 'components/navi';
 @import 'components/stats';
+@import 'components/project-tile';
 
 @import '~a4-meinberlin/meinberlin/assets/scss/utility';
 @import '~a4-meinberlin/meinberlin/assets/scss/shame';


### PR DESCRIPTION
- includes #16 (by mistake)
- Adds basic tiles for the coming projects
- Structure in the project tiles (head, labels, description, date)
- Example (static) information for seeing the structure
- Adaption to smaller screens

Missing
- [ ] Adaption for longer texts.
- [ ] Backend: Get information from an actual project.
- [ ] Backend: Reasonable usage of the labels.
- [ ] Design/Layout for smaller screens.