### PR TITLE
Update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
   - pip install -r requirements/dev.txt
 script:
   - py.test --cov
+  - python manage.py makemigrations --dry-run --check --noinput
   - ./node_modules/.bin/polylint -F
 deploy:
  - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.5"
+  - "3.4"
 cache: pip
 install:
   - nvm install 6


### PR DESCRIPTION
* Change travis python version to 3.4
  On our servers python 3.4 is running so we should use that version on travis, too
* Make travis fail if there are missing migrations