### PR TITLE
2017 12 ka fix tab breaking

### DIFF
--- a/liqd_product/assets/scss/_variables.scss
+++ b/liqd_product/assets/scss/_variables.scss
@@ -40,3 +40,5 @@ $brand-success: #90efe4 !default; // $brand-secondary from platform.scss
 $brand-info: #2d40cc !default; // $brand-primary from platform.scss
 $brand-warning: #ffc107 !default;
 $brand-danger: #d0011b !default; // $plattform-danger
+
+$breakpoint-xs: 33em !default;

--- a/liqd_product/assets/scss/components/_tabs.scss
+++ b/liqd_product/assets/scss/components/_tabs.scss
@@ -20,3 +20,11 @@
         background-color: $body-bg;
     }
 }
+
+@media (max-width: $breakpoint) {
+    .tab {
+        margin-right: -4px;
+        padding-right: 0.3em;
+        padding-left: 0.3em;
+    }
+}

--- a/liqd_product/assets/scss/components/_tabs.scss
+++ b/liqd_product/assets/scss/components/_tabs.scss
@@ -22,7 +22,7 @@
     }
 }
 
-@media (max-width: $breakpoint) {
+@media (max-width: $breakpoint-xs) {
     .tab {
         margin-right: -4px;
         padding-right: 0.3em;

--- a/liqd_product/assets/scss/components/_tabs.scss
+++ b/liqd_product/assets/scss/components/_tabs.scss
@@ -4,6 +4,7 @@
 
 .tab {
     color: $text-secondary-color;
+    padding: 0.6em 1em;
     margin-bottom: -2px;
     border: 2px solid transparent;
     border-top-right-radius: 0;

--- a/liqd_product/assets/scss/components/_tabs.scss
+++ b/liqd_product/assets/scss/components/_tabs.scss
@@ -28,7 +28,9 @@
         padding-right: 0.3em;
         padding-left: 0.3em;
     }
+}
 
+@media (max-width: $breakpoint) {
     .tablist__right,
     .tablist__left {
         margin-bottom: 1em;

--- a/liqd_product/assets/scss/components/_tabs.scss
+++ b/liqd_product/assets/scss/components/_tabs.scss
@@ -28,4 +28,14 @@
         padding-right: 0.3em;
         padding-left: 0.3em;
     }
+
+    .tablist__right,
+    .tablist__left {
+        margin-bottom: 1em;
+    }
+
+    .tablist__right + nav,
+    .tablist__left + nav {
+        clear: both;
+    }
 }


### PR DESCRIPTION
fixes #204 (together with https://github.com/liqd/a4-meinberlin/pull/1110)
also fixes half a point of #191 (the padding of the tabs is bigger now)

I introduced a breakpoint-xs, because otherwise the tabs look very cramped when that's not yet necessary.