### PR TITLE
Enable collapsibles in project information

### DIFF
--- a/liqd_product/assets/scss/components/_accordion.scss
+++ b/liqd_product/assets/scss/components/_accordion.scss
@@ -1,0 +1,58 @@
+.accordion {
+    border: solid 1px $border-color;
+    border-radius: 5px;
+
+    // make border-radius work with contents
+    overflow: hidden;
+    margin-bottom: $padding * 1.8;
+}
+
+.accordion__title {
+    display: block;
+    position: relative;
+    padding: $padding/2 1em $padding/2 1.2em;
+    color: inherit;
+    border-bottom: solid 1px $border-color;
+
+    &.collapsed {
+        border-bottom: none;
+    }
+
+    h2 {
+        font-size: $font-size-lg;
+        margin-top: $spacer / 5;
+        margin-bottom: $spacer / 5;
+    }
+
+    i {
+        position: absolute;
+        top: 0.7em;
+        right: $padding;
+        transition: transform 0.3s;
+        color: $border-color;
+    }
+
+    &[aria-expanded="true"] i {
+        transform: rotate(180deg);
+    }
+}
+
+.accordion__body {
+    padding: $padding / 2;
+
+    ul {
+        list-style: none;
+        margin-left: 0;
+        padding: 0;
+    }
+
+    li {
+        margin-bottom: 0.2em;
+    }
+
+    a[href^="/documents"]:before {
+        content: '\f016'; // file-o
+        font-family: 'FontAwesome', sans-serif;
+        margin-right: 0.3em;
+    }
+}

--- a/liqd_product/assets/scss/style.scss
+++ b/liqd_product/assets/scss/style.scss
@@ -19,6 +19,7 @@
 @import '~a4-meinberlin/meinberlin/assets/scss/form';
 @import 'form';
 
+@import '~a4-meinberlin/meinberlin/assets/scss/components/accordion';
 @import '~a4-meinberlin/meinberlin/assets/scss/components/action';
 @import '~a4-meinberlin/meinberlin/assets/scss/components/blocks';
 @import '~a4-meinberlin/meinberlin/assets/scss/components/breadcrumbs';

--- a/liqd_product/assets/scss/style.scss
+++ b/liqd_product/assets/scss/style.scss
@@ -19,7 +19,6 @@
 @import '~a4-meinberlin/meinberlin/assets/scss/form';
 @import 'form';
 
-@import '~a4-meinberlin/meinberlin/assets/scss/components/accordion';
 @import '~a4-meinberlin/meinberlin/assets/scss/components/action';
 @import '~a4-meinberlin/meinberlin/assets/scss/components/blocks';
 @import '~a4-meinberlin/meinberlin/assets/scss/components/breadcrumbs';
@@ -56,6 +55,7 @@
 @import '~a4-meinberlin/meinberlin/assets/scss/components/tabs';
 @import '~a4-meinberlin/meinberlin/assets/scss/components/upload';
 
+@import 'components/accordion';
 @import 'components/alerts';
 @import 'components/aside';
 @import 'components/button';

--- a/liqd_product/config/settings/base.py
+++ b/liqd_product/config/settings/base.py
@@ -264,6 +264,17 @@ CKEDITOR_CONFIGS = {
             ['NumberedList', 'BulletedList'],
             ['Link', 'Unlink']
         ]
+    },
+    'collapsible-image-editor': {
+        'width': '100%',
+        'toolbar': 'Custom',
+        'toolbar_Custom': [
+            ['Bold', 'Italic', 'Underline'],
+            ['Image'],
+            ['NumberedList', 'BulletedList'],
+            ['Link', 'Unlink'],
+            ['CollapsibleItem']
+        ]
     }
 }
 
@@ -279,6 +290,26 @@ BLEACH_LIST = {
         'attributes': {
             'a': ['href', 'rel'],
             'img': ['src', 'alt', 'style']
+        },
+        'styles': [
+            'float',
+            'margin',
+            'padding',
+            'width',
+            'height',
+            'margin-bottom',
+            'margin-top',
+            'margin-left',
+            'margin-right',
+        ],
+    },
+    'collapsible-image-editor': {
+        'tags': ['p', 'strong', 'em', 'u', 'ol', 'li', 'ul', 'a', 'img',
+                 'div'],
+        'attributes': {
+            'a': ['href', 'rel'],
+            'img': ['src', 'alt', 'style'],
+            'div': ['class']
         },
         'styles': [
             'float',

--- a/liqd_product/config/settings/base.py
+++ b/liqd_product/config/settings/base.py
@@ -56,6 +56,7 @@ INSTALLED_APPS = (
     # General adhocracy 4 components
     'adhocracy4.actions.apps.ActionsConfig',
     'adhocracy4.categories.apps.CategoriesConfig',
+    'adhocracy4.ckeditor.apps.CKEditorConfig',
     'adhocracy4.comments.apps.CommentsConfig',
     'adhocracy4.filters.apps.FiltersConfig',
     'adhocracy4.follows.apps.FollowsConfig',

--- a/liqd_product/templates/a4ckeditor/collapsible_fragment.html
+++ b/liqd_product/templates/a4ckeditor/collapsible_fragment.html
@@ -1,0 +1,25 @@
+{% load wagtailcore_tags %}
+
+<div class="accordion">
+    <a
+        id="{{ id }}-title"
+        href="#{{ id }}-body"
+        aria-haspopup="true"
+        aria-expanded="false"
+        aria-controls="{{ id }}-body"
+        data-toggle="collapse"
+        class="accordion__title collapsed"
+        >
+        <h2>
+            {{ title|safe }}
+            <i class="fa fa-chevron-down" aria-hidden="true"></i>
+        </h2>
+    </a>
+
+    <div
+        class="accordion__body collapse"
+        id="{{ id }}-body"
+        aria-labelledby="{{ id }}-title">
+        {{ body|richtext }}
+    </div>
+</div>

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "webpack": "3.10.0",
     "webpack-merge": "4.1.1",
 
-    "adhocracy4": "liqd/adhocracy4#5c5a5f5a811c37410e683941673a3712564ea019",
-    "a4-meinberlin": "github:liqd/a4-meinberlin#9bfe49bac4663a78d1496d7bfb074a47128e615c",
+    "adhocracy4": "liqd/adhocracy4#0432f796118d2fe918e6851f64916bae18e4c8e3",
+    "a4-meinberlin": "github:liqd/a4-meinberlin#7e2b541854c10c1de3a9acfdd0033b50066c9d42",
     "bootstrap": "4.0.0-alpha.6",
     "datepicker": "git+https://github.com/liqd/datePicker.git",
     "leaflet": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "webpack": "3.10.0",
     "webpack-merge": "4.1.1",
 
-    "adhocracy4": "liqd/adhocracy4#master",
-    "a4-meinberlin": "github:liqd/a4-meinberlin#master",
+    "adhocracy4": "liqd/adhocracy4#5c5a5f5a811c37410e683941673a3712564ea019",
+    "a4-meinberlin": "github:liqd/a4-meinberlin#9bfe49bac4663a78d1496d7bfb074a47128e615c",
     "bootstrap": "4.0.0-alpha.6",
     "datepicker": "git+https://github.com/liqd/datePicker.git",
     "leaflet": "1.2.0",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
-git+git://github.com/liqd/adhocracy4.git@master#egg=adhocracy4
-git+git://github.com/liqd/a4-meinberlin.git@master#egg=a4-meinberlin-libs
+git+git://github.com/liqd/adhocracy4.git@5c5a5f5a811c37410e683941673a3712564ea019#egg=adhocracy4
+git+git://github.com/liqd/a4-meinberlin.git@9bfe49bac4663a78d1496d7bfb074a47128e615c#egg=a4-meinberlin-libs
 
 # Inherited a4-meinberlin requirements
 bcrypt==3.1.4

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,6 @@ git+git://github.com/liqd/a4-meinberlin.git@master#egg=a4-meinberlin-libs
 # Inherited a4-meinberlin requirements
 bcrypt==3.1.4
 django-capture-tag==1.0
-html5lib==1.0.1
 wagtail==1.12.3 # pyup: <1.13
 XlsxWriter==1.0.2
 zeep==2.4.0
@@ -20,6 +19,7 @@ django-filter==1.1.0
 django-widget-tweaks==1.4.1
 djangorestframework==3.7.7
 easy-thumbnails==2.5
+html5lib==1.0.1
 jsonfield==2.0.2
 python-dateutil==2.6.1
 python-magic==0.4.15

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
-git+git://github.com/liqd/adhocracy4.git@5c5a5f5a811c37410e683941673a3712564ea019#egg=adhocracy4
-git+git://github.com/liqd/a4-meinberlin.git@9bfe49bac4663a78d1496d7bfb074a47128e615c#egg=a4-meinberlin-libs
+git+git://github.com/liqd/adhocracy4.git@0432f796118d2fe918e6851f64916bae18e4c8e3#egg=adhocracy4
+git+git://github.com/liqd/a4-meinberlin.git@7e2b541854c10c1de3a9acfdd0033b50066c9d42#egg=a4-meinberlin-libs
 
 # Inherited a4-meinberlin requirements
 bcrypt==3.1.4


### PR DESCRIPTION
depends on liqd/a4-meinberlin#1146 and liqd/adhocracy4#235

This also introduces internal dependency pinning

Note, that the dependencies are currently pointing to the last commit within the PR. maybe we should update them to the merge commit after a4 has been merged