### PR TITLE
Change default map bounding box to germany, closes #218

### DIFF
--- a/liqd_product/config/settings/base.py
+++ b/liqd_product/config/settings/base.py
@@ -404,7 +404,7 @@ A4_CATEGORY_ICONS = (
 
 A4_MAP_BASEURL = 'https://{s}.tile.openstreetmap.org/'
 A4_MAP_ATTRIBUTION = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-A4_MAP_BOUNDING_BOX = ([[52.3517, 13.8229], [52.6839, 12.9543]])
+A4_MAP_BOUNDING_BOX = ([[54.983, 15.016], [47.302, 5.988]])
 
 A4_DASHBOARD = {
     'PROJECT_DASHBOARD_CLASS': 'meinberlin.apps.dashboard.ProjectDashboard',


### PR DESCRIPTION
For the user it could be tedious to zoom into a certain place from germany. I briefly explored the possibility of having an extra field in the Partner for the default bounding box, but its at least not obvious how to do it that way.