### PR TITLE
Ka 2018 04 align settings and make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+.pytest_cache
 
 # Translations
 *.mo
@@ -23,9 +24,14 @@ coverage.xml
 
 # Environments
 venv/
+/pyvenv.cfg
+/pip-selfcheck.json
 
 # Node
 node_modules/
+package-lock.json
+npm-debug.log*
+/webpack-stats.json
 
 # IDEs
 .idea/
@@ -40,3 +46,18 @@ liqd_product/config/settings/local.py
 # Generated static files
 liqd_product/static/
 static/
+
+# Media
+media/
+
+# setuptools
+/build
+/dist
+/*.egg-info
+/share
+
+# OS
+.DS_Store
+
+# sass
+.sass-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ cache:
 install:
   - nvm install 6
   - npm install
+  - npm run build
   - pip install -r requirements/dev.txt
   - pip install coveralls
 script:
   - py.test --cov
   - python manage.py makemigrations --dry-run --check --noinput
   - ./node_modules/.bin/polylint -F
-  - npm run build
 after_success:
   - coveralls
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,9 @@ help:
 .PHONY: install
 install:
 	npm install --no-save
+	npm run build
 	if [ ! -f $(VIRTUAL_ENV)/bin/python3 ]; then python3 -m venv $(VIRTUAL_ENV); fi
-	$(VIRTUAL_ENV)/bin/python3 -m pip install -r requirements/dev.txt
+	$(VIRTUAL_ENV)/bin/python3 -m pip install --upgrade -r requirements/dev.txt
 	$(VIRTUAL_ENV)/bin/python3 manage.py migrate
 
 .PHONY: makemessages

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,12 @@ help:
 	@echo Beteiligung.in development tools
 	@echo
 	@echo It will either use an exisiting virtualenv if it was entered
-	@echo before or create a new one in the .env subdirectory.
+	@echo before or create a new one in the venv subdirectory.
 	@echo
 	@echo usage:
 	@echo
 	@echo "  make install         -- install dev setup"
+	@echo "  make clean           -- delete node modules and venv"
 	@echo "  make server          -- start a dev server"
 	@echo "  make watch           -- start a dev server and rebuild js and css files on changes"
 	@echo "  make background      -- start a dev server, rebuild js and css files on changes, and start background processes"
@@ -39,7 +40,7 @@ install:
 .PHONY: clean
 clean:
 	if [ -d node_modules ]; then rm -r node_modules; fi
-	$(VIRTUAL_ENV)/bin/python3 -m pip uninstall -y -r requirements/dev.txt
+	if [ -d venv ]; then rm -r venv; fi
 
 .PHONY: server
 server:

--- a/Makefile
+++ b/Makefile
@@ -31,35 +31,14 @@ install:
 	$(VIRTUAL_ENV)/bin/python3 -m pip install --upgrade -r requirements/dev.txt
 	$(VIRTUAL_ENV)/bin/python3 manage.py migrate
 
-.PHONY: makemessages
-makemessages:
-	$(VIRTUAL_ENV)/bin/python manage.py makemessages -d django
-	$(VIRTUAL_ENV)/bin/python manage.py makemessages -d djangojs
-	sed -i 's%#: .*/adhocracy4%#: adhocracy4%' locale/*/LC_MESSAGES/django*.po
-	sed -i 's%#: .*/a4-meinberlin%#: a4-meinberlin%' locale/*/LC_MESSAGES/django*.po
-	msgen locale/en_GB/LC_MESSAGES/django.po -o locale/en_GB/LC_MESSAGES/django.po
-	msgen locale/en_GB/LC_MESSAGES/djangojs.po -o locale/en_GB/LC_MESSAGES/djangojs.po
-
-.PHONY: compilemessages
-compilemessages:
-	$(VIRTUAL_ENV)/bin/python manage.py compilemessages
-
-.PHONY: server
-server:
-	$(VIRTUAL_ENV)/bin/python3 manage.py runserver 8004
-
 .PHONY: watch
 watch:
 	npm run watch & \
 	$(VIRTUAL_ENV)/bin/python3 manage.py runserver 8004
 
-.PHONY: lint
-lint:
-	. $(VIRTUAL_ENV)/bin/activate && $(NODE_BIN)/polylint
-
-.PHONY: lint-quick
-lint-quick:
-	. $(VIRTUAL_ENV)/bin/activate && $(NODE_BIN)/polylint -SF
+.PHONY: server
+server:
+	$(VIRTUAL_ENV)/bin/python3 manage.py runserver 8004
 
 .PHONY: test
 test:
@@ -72,6 +51,27 @@ test-lastfailed:
 .PHONY: test-clean
 test-clean:
 	if [ -f test_db.sqlite3 ]; then rm test_db.sqlite3; fi
+
+.PHONY: lint
+lint:
+	. $(VIRTUAL_ENV)/bin/activate && $(NODE_BIN)/polylint
+
+.PHONY: lint-quick
+lint-quick:
+	. $(VIRTUAL_ENV)/bin/activate && $(NODE_BIN)/polylint -SF
+
+.PHONY: makemessages
+makemessages:
+	$(VIRTUAL_ENV)/bin/python manage.py makemessages -d django
+	$(VIRTUAL_ENV)/bin/python manage.py makemessages -d djangojs
+	sed -i 's%#: .*/adhocracy4%#: adhocracy4%' locale/*/LC_MESSAGES/django*.po
+	sed -i 's%#: .*/a4-meinberlin%#: a4-meinberlin%' locale/*/LC_MESSAGES/django*.po
+	msgen locale/en_GB/LC_MESSAGES/django.po -o locale/en_GB/LC_MESSAGES/django.po
+	msgen locale/en_GB/LC_MESSAGES/djangojs.po -o locale/en_GB/LC_MESSAGES/djangojs.po
+
+.PHONY: compilemessages
+compilemessages:
+	$(VIRTUAL_ENV)/bin/python manage.py compilemessages
 
 .PHONY: release
 release: export DJANGO_SETTINGS_MODULE ?= liqd_product.config.settings.build

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,11 @@ help:
 	@echo "  make test            -- run all test cases with pytest"
 	@echo "  make test-lastfailed -- run test that failed last"
 	@echo "  make test-clean      -- test on new database"
+	@echo "  make coverage        -- write coverage report to dir htmlcov"
 	@echo "  make lint            -- lint all project files"
 	@echo "  make lint-quick      -- lint all files staged in git"
-	@echo "  make makemessages    -- create new po files from the source"
-	@echo "  make compilemessages -- create new mo files from the translated po files"
+	@echo "  make po              -- create new po files from the source"
+	@echo "  make mo              -- create new mo files from the translated po files"
 	@echo "  make release         -- build everything required for a release"
 	@echo
 
@@ -64,6 +65,10 @@ test-clean:
 	if [ -f test_db.sqlite3 ]; then rm test_db.sqlite3; fi
 	$(VIRTUAL_ENV)/bin/py.test
 
+.PHONY: coverage
+coverage:
+	$(VIRTUAL_ENV)/bin/py.test --reuse-db --cov --cov-report=html
+
 .PHONY: lint
 lint:
 	. $(VIRTUAL_ENV)/bin/activate && $(NODE_BIN)/polylint
@@ -72,8 +77,8 @@ lint:
 lint-quick:
 	. $(VIRTUAL_ENV)/bin/activate && $(NODE_BIN)/polylint -SF
 
-.PHONY: makemessages
-makemessages:
+.PHONY: po
+po:
 	$(VIRTUAL_ENV)/bin/python manage.py makemessages -d django
 	$(VIRTUAL_ENV)/bin/python manage.py makemessages -d djangojs
 	sed -i 's%#: .*/adhocracy4%#: adhocracy4%' locale/*/LC_MESSAGES/django*.po
@@ -81,8 +86,8 @@ makemessages:
 	msgen locale/en_GB/LC_MESSAGES/django.po -o locale/en_GB/LC_MESSAGES/django.po
 	msgen locale/en_GB/LC_MESSAGES/djangojs.po -o locale/en_GB/LC_MESSAGES/djangojs.po
 
-.PHONY: compilemessages
-compilemessages:
+.PHONY: mo
+mo:
 	$(VIRTUAL_ENV)/bin/python manage.py compilemessages
 
 .PHONY: release

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,11 @@ install:
 	$(VIRTUAL_ENV)/bin/python3 -m pip install --upgrade -r requirements/dev.txt
 	$(VIRTUAL_ENV)/bin/python3 manage.py migrate
 
+.PHONY: clean
+clean:
+	if [ -d node_modules ]; then rm -r node_modules; fi
+	$(VIRTUAL_ENV)/bin/python3 -m pip uninstall -y -r requirements/dev.txt
+
 .PHONY: server
 server:
 	$(VIRTUAL_ENV)/bin/python3 manage.py runserver 8004

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,11 @@ help:
 	@echo usage:
 	@echo
 	@echo "  make install         -- install dev setup"
-	@echo "  make lint            -- lint all project files"
-	@echo "  make lint-quick      -- lint all files staged in git"
 	@echo "  make server          -- start a dev server"
 	@echo "  make watch           -- start a dev server and rebuild js and css files on changes"
+	@echo "  make background   -- start a dev server, rebuild js and css files on changes, and start background processes"
+	@echo "  make lint            -- lint all project files"
+	@echo "  make lint-quick      -- lint all files staged in git"
 	@echo "  make test            -- run all test cases with pytest"
 	@echo "  make makemessages    -- create new po files from the source"
 	@echo "  make compilemessages -- create new mo files from the translated po files"
@@ -31,13 +32,21 @@ install:
 	$(VIRTUAL_ENV)/bin/python3 -m pip install --upgrade -r requirements/dev.txt
 	$(VIRTUAL_ENV)/bin/python3 manage.py migrate
 
+.PHONY: server
+server:
+	$(VIRTUAL_ENV)/bin/python3 manage.py runserver 8004
+
 .PHONY: watch
 watch:
+	trap 'kill %1' KILL; \
 	npm run watch & \
 	$(VIRTUAL_ENV)/bin/python3 manage.py runserver 8004
 
-.PHONY: server
-server:
+.PHONY: background
+background:
+	trap 'kill %1; kill %2' KILL; \
+	npm run watch & \
+	$(VIRTUAL_ENV)/bin/python3 manage.py process_tasks & \
 	$(VIRTUAL_ENV)/bin/python3 manage.py runserver 8004
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,12 @@ help:
 	@echo "  make install         -- install dev setup"
 	@echo "  make server          -- start a dev server"
 	@echo "  make watch           -- start a dev server and rebuild js and css files on changes"
-	@echo "  make background   -- start a dev server, rebuild js and css files on changes, and start background processes"
+	@echo "  make background      -- start a dev server, rebuild js and css files on changes, and start background processes"
+	@echo "  make test            -- run all test cases with pytest"
+	@echo "  make test-lastfailed -- run test that failed last"
+	@echo "  make test-clean      -- test on new database"
 	@echo "  make lint            -- lint all project files"
 	@echo "  make lint-quick      -- lint all files staged in git"
-	@echo "  make test            -- run all test cases with pytest"
 	@echo "  make makemessages    -- create new po files from the source"
 	@echo "  make compilemessages -- create new mo files from the translated po files"
 	@echo "  make release         -- build everything required for a release"
@@ -60,6 +62,7 @@ test-lastfailed:
 .PHONY: test-clean
 test-clean:
 	if [ -f test_db.sqlite3 ]; then rm test_db.sqlite3; fi
+	$(VIRTUAL_ENV)/bin/py.test
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ help:
 	@echo "  make lint            -- lint all project files"
 	@echo "  make lint-quick      -- lint all files staged in git"
 	@echo "  make po              -- create new po files from the source"
-	@echo "  make mo              -- create new mo files from the translated po files"
+	@echo "  make compilemessages -- create new mo files from the translated po files"
 	@echo "  make release         -- build everything required for a release"
 	@echo
 
@@ -93,8 +93,8 @@ po:
 	msgen locale/en_GB/LC_MESSAGES/django.po -o locale/en_GB/LC_MESSAGES/django.po
 	msgen locale/en_GB/LC_MESSAGES/djangojs.po -o locale/en_GB/LC_MESSAGES/djangojs.po
 
-.PHONY: mo
-mo:
+.PHONY: compilemessages
+compilemessages:
 	$(VIRTUAL_ENV)/bin/python manage.py compilemessages
 
 .PHONY: release

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 VIRTUAL_ENV ?= venv
 NODE_BIN = node_modules/.bin
 
+.PHONY: all
 all: help
 
 .PHONY: help


### PR DESCRIPTION
I aligned all the Makefiles in our four projects.
They are always in the same order and nearly have the same targets now.

I wanted to also add clean as a target to get rid of all installed packages, but couldn't quite figure out how to. For the node modules, I think the best way is to just delete the folder, like I do. But for the python packages, I am unsure. In the current version only the packages from the requirements are uninstalled, but everything from 3rd-party packages is still there. And it complains if I run it twice. Another option would be to write the output of pip freeze into a text file and then uninstall all of those. Or we could just delete folders. But which? If we just delete the whole venv, we should make sure that it is deactivated prior to it?