### PR TITLE
update mB

### DIFF
--- a/liqd_product/config/settings/base.py
+++ b/liqd_product/config/settings/base.py
@@ -91,7 +91,6 @@ INSTALLED_APPS = (
     'liqd_product.apps.account.apps.Config',
     'liqd_product.apps.dashboard.apps.Config',
     'meinberlin.apps.embed.apps.Config',
-    'meinberlin.apps.exports.apps.Config',
     'meinberlin.apps.offlineevents.apps.Config',
     'meinberlin.apps.projects.apps.Config',
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "webpack-merge": "4.1.2",
 
     "adhocracy4": "liqd/adhocracy4#31bd992a1813208c5aa44a0cebb2fe00bdea6f34",
-    "a4-meinberlin": "github:liqd/a4-meinberlin#8863ccfad80a22a06a3441544d9ed9a643a59c17",
+    "a4-meinberlin": "github:liqd/a4-meinberlin#fa91d2d1f4845ab4b3d2096a99906ad826dc31a0",
     "bootstrap": "4.0.0-alpha.6",
     "datepicker": "git+https://github.com/liqd/datePicker.git",
     "leaflet": "1.3.1",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 git+git://github.com/liqd/adhocracy4.git@31bd992a1813208c5aa44a0cebb2fe00bdea6f34#egg=adhocracy4
-git+git://github.com/liqd/a4-meinberlin.git@8863ccfad80a22a06a3441544d9ed9a643a59c17#egg=a4-meinberlin-libs
+git+git://github.com/liqd/a4-meinberlin.git@fa91d2d1f4845ab4b3d2096a99906ad826dc31a0#egg=a4-meinberlin-libs
 
 # Inherited a4-meinberlin requirements
 bcrypt==3.1.4


### PR DESCRIPTION
The export does not actually work (if there are comments). But this is the case for all exports that use the https://github.com/liqd/adhocracy4/blob/92d73335802a14e7bcc25d6c6e58945215002727/adhocracy4/exports/mixins.py#L15 in meinBerlin. The export for brainstorming does also not work for example. This is because get_absolute_url does not work here, because it doesn't get/know the partner slug. While we could somehow fix it for the Mixin, that doesn't seem like the best idea, bacause that might be a problem we could get over and over again. 