### PR TITLE
Add mapbox dependencies

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -28,9 +28,15 @@ module.exports = {
     ],
     leaflet: [
       'leaflet',
+      'mapbox-gl-leaflet',
+      'mapbox-gl/dist/mapbox-gl.js',
+      'mapbox-gl/dist/mapbox-gl.css',
       'leaflet/dist/leaflet.css',
       'leaflet.markercluster',
       'leaflet.markercluster/dist/MarkerCluster.css'
+    ],
+    'mapboxgl': [
+      'mapbox-gl/dist/mapbox-gl.js'
     ],
     datepicker: [
       './liqd_product/assets/js/init-picker.js',


### PR DESCRIPTION
Without this, modules with maps will throw a 500 error.

Test case: https://product-dev-teststadt.liqd.net/projects/neues-gemeindezentrum-in-teststadt/