### PR TITLE
apps/actions: read current language from html tag

### DIFF
--- a/liqd_product/apps/actions/assets/timestamps.js
+++ b/liqd_product/apps/actions/assets/timestamps.js
@@ -11,7 +11,7 @@ $(function () {
     let timeagoInstance = timeago()
 
     if ((new Date() - datetime) < sevenDays) {
-      e.textContent = timeagoInstance.format(datetime, 'en')
+      e.textContent = timeagoInstance.format(datetime, document.documentElement.lang)
     }
   })
 })


### PR DESCRIPTION
timestamp.js is used to display ' xx minutes ago' instead of the timestamp
if an action in the actionlist on the organisation's landing page
happened less then an hour ago (it uses an external library,
timeago.js). Because the text differs in each language we need to get
the current language, which we can read from the html tag. The
translation comes from timeago.js.