### PR TITLE
tests: Make sure tests use valid random numbers

### DIFF
--- a/tests/documents/factories.py
+++ b/tests/documents/factories.py
@@ -12,7 +12,7 @@ class ChapterFactory(factory.django.DjangoModelFactory):
     name = factory.Faker('sentence')
     creator = factory.SubFactory(a4_factories.USER_FACTORY)
     module = factory.SubFactory(a4_factories.ModuleFactory)
-    weight = factory.Faker('random_number')
+    weight = factory.Faker('random_number', digits=3)
 
 
 class ParagraphFactory(factory.django.DjangoModelFactory):
@@ -22,5 +22,5 @@ class ParagraphFactory(factory.django.DjangoModelFactory):
 
     name = factory.Faker('sentence')
     text = 'text'
-    weight = factory.Faker('random_number')
+    weight = factory.Faker('random_number', digits=3)
     chapter = factory.SubFactory(ChapterFactory)

--- a/tests/polls/factories.py
+++ b/tests/polls/factories.py
@@ -21,7 +21,7 @@ class QuestionFactory(factory.django.DjangoModelFactory):
         model = models.Question
 
     label = factory.Faker('sentence')
-    weight = factory.Faker('random_number')
+    weight = factory.Faker('random_number', digits=3)
     poll = factory.SubFactory(PollFactory)
 
 


### PR DESCRIPTION
The 'weight' arguments is set to 'smallint'. Sqlite does not care
about it, but postgres throws test errors if the random number does
not fit. Use a three digit number.