### PR TITLE
apps/account: Redirect unauthenticated users

### DIFF
--- a/apps/account/views.py
+++ b/apps/account/views.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
 from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext_lazy as _
@@ -17,7 +18,8 @@ class AccountView(RedirectView):
     # dashboard function overview.
 
 
-class ProfileUpdateView(SuccessMessageMixin,
+class ProfileUpdateView(LoginRequiredMixin,
+                        SuccessMessageMixin,
                         generic.UpdateView):
 
     model = User


### PR DESCRIPTION
This fixes the anoying case of logging from this view, resulting
in a 404 error. Redirect back to login instead.