### PR TITLE
cms/styling: display h1 and h2 of cms index pages smaller

### DIFF
--- a/apps/cms/news/templates/a4_candy_cms_news/news_index_page.html
+++ b/apps/cms/news/templates/a4_candy_cms_news/news_index_page.html
@@ -10,7 +10,7 @@
     <div class="container">
         <div class="row justify-content-md-center">
             <div class="col-12 col-lg-10">
-                <h1 class="cms__title--serif cms__title--underlined text-center">{{ page.subtitle }}</h1>
+                <h1 class="cms__title--serif cms__title--underlined cms__title--h2-size text-center">{{ page.subtitle }}</h1>
                 <div class="row justify-content-start">
                 {% for post in news %}
                     <div class="col-12 col-md-6 cms-news__tile">
@@ -18,7 +18,7 @@
                             <div class="cms__text text-muted">
                                 {{ post.first_published_at|date }}
                             </div>
-                            <h3 class="cms__title--bold cms-news__header-margin">{{ post.subtitle }}</h3>
+                            <h2 class="cms__title--bold cms-news__header-margin cms__title--h3-size">{{ post.subtitle }}</h2>
                             <div class="cms__text">
                                 {{ post.teaser }}
                             </div>

--- a/apps/cms/use_cases/templates/a4_candy_cms_use_cases/use_case_index_page.html
+++ b/apps/cms/use_cases/templates/a4_candy_cms_use_cases/use_case_index_page.html
@@ -11,7 +11,7 @@
     <div class="container">
         <div class="row justify-content-center">
             <div class="col-12 col-lg-8">
-                <h1 class="cms__title--serif cms__title--underlined text-center">{{ page.subtitle }}</h1>
+                <h1 class="cms__title--serif cms__title--underlined cms__title--h2-size text-center">{{ page.subtitle }}</h1>
             </div>
         </div>
         <div class="row justify-content-center mb-5">
@@ -79,8 +79,8 @@
                     <div class="cms__text pt-4">
                         {% blocktrans with category=use_case.get_category_display %}For {{ category }}{% endblocktrans %}
                     </div>
-                    <h3 class="cms__title--bold">{{ use_case.title }}
-                    </h3>
+                    <h2 class="cms__title--bold cms__title--h3-size">{{ use_case.title }}
+                    </h2>
                 </a>
             </div>
             {% endfor %}

--- a/liqd_product/assets/scss/components/_cms.scss
+++ b/liqd_product/assets/scss/components/_cms.scss
@@ -34,6 +34,22 @@
     }
 }
 
+.cms__title--h2-size {
+    font-size: $font-size-xxl;
+
+    @media screen and (max-width: $breakpoint-xs-down) {
+        font-size: $mobile-headline-size*$font-size-xxl;
+    }
+}
+
+.cms__title--h3-size {
+    font-size: $font-size-xl;
+
+    @media screen and (max-width: $breakpoint-xs-down) {
+        font-size: $mobile-headline-size*$font-size-xl;
+    }
+}
+
 .cms__text {
     font-size: $font-size-md;
     font-family: $font-family-base;


### PR DESCRIPTION
Alright, the headlines on the index pages are menat to be smaller. But because a11y and SEO, we need one h1 per page and shouldn't skip some inbetween (so no h3 directly after h1). I don't know if this is the best solution, but couldn't think of another one. What do you think @phillimorland ?

fixes #924 